### PR TITLE
Added test-suite and examples to the cabal file

### DIFF
--- a/LambdaNet.cabal
+++ b/LambdaNet.cabal
@@ -45,6 +45,33 @@ library
     Histogram,
     hspec
 
+executable convolutional
+  main-is: Convolutional.hs
+  hs-source-dirs: examples
+  build-depends:
+    base >= 4 && < 5,
+    LambdaNet,
+    hmatrix >= 0.17.0.1,
+    random
+
+executable som
+  main-is: SOM.hs
+  hs-source-dirs: examples
+  build-depends:
+    base >= 4 && < 5,
+    LambdaNet,
+    hmatrix >= 0.17.0.1,
+    random
+
+executable xor
+  main-is: XOR.hs
+  hs-source-dirs: examples
+  build-depends:
+    base >= 4 && < 5,
+    LambdaNet,
+    hmatrix >= 0.17.0.1,
+    random
+
 test-suite test-all
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/LambdaNet.cabal
+++ b/LambdaNet.cabal
@@ -44,3 +44,13 @@ library
     bytestring,
     Histogram,
     hspec
+
+test-suite test-all
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  build-depends:
+    base >= 4 && < 5,
+    LambdaNet,
+    hspec,
+    QuickCheck

--- a/LambdaNet.cabal
+++ b/LambdaNet.cabal
@@ -22,6 +22,10 @@ cabal-version:       >=1.8
 extra-source-files:  README.md
                      Changelog
 
+flag examples
+    Description: Enable examples
+    Default:     False
+
 library
   exposed-modules:
     AI.Network,
@@ -53,6 +57,10 @@ executable convolutional
     LambdaNet,
     hmatrix >= 0.17.0.1,
     random
+  if flag(examples)
+    buildable:         True
+  else
+    buildable:         False
 
 executable som
   main-is: SOM.hs
@@ -62,6 +70,10 @@ executable som
     LambdaNet,
     hmatrix >= 0.17.0.1,
     random
+  if flag(examples)
+    buildable:         True
+  else
+    buildable:         False
 
 executable xor
   main-is: XOR.hs
@@ -71,6 +83,10 @@ executable xor
     LambdaNet,
     hmatrix >= 0.17.0.1,
     random
+  if flag(examples)
+    buildable:         True
+  else
+    buildable:         False
 
 test-suite test-all
   type: exitcode-stdio-1.0


### PR DESCRIPTION
The tests can be run with either `stack test` or `cabal test`.

Build the examples with either `stack build --flag LambdaNet:examples`
or `cabal configure -f examples && cabal build`.

After that they can be run with `stack build && stack exec xor` or `cabal run xor`.
